### PR TITLE
safehouse boxes + loadout actions

### DIFF
--- a/fnc/_server/ins/fn_ins_safehouseEquipment.sqf
+++ b/fnc/_server/ins/fn_ins_safehouseEquipment.sqf
@@ -67,7 +67,7 @@ clearMagazineCargo _crate;
 clearBackpackCargoGlobal _crate;
 switch(_type) do
 {
-    case "CUP_USSpecialWeapons_EP1":{["AmmoboxInit",[_crate, true]] spawn BIS_fnc_arsenal; _crate addAction["<t color='#B570E8C9'> Loadout </t>", { createDialog "dialog_LoadoutRequest" },"",1,true,false,"","(side player == civilian)"];};
+    case "CUP_USSpecialWeapons_EP1":{["AmmoboxInit",[_crate, true]] spawn BIS_fnc_arsenal; _crate addAction["<t color='#B570E8C9'>Loadout</t>", { createDialog "dialog_LoadoutRequest" },"",6,true,false,"","(side player == civilian)"];};
     case "Box_CSAT_Equip_F": {{_crate addItemCargoGlobal [_x select 0, _x select 1]}forEach _insAceEquipment};
     case "Box_CSAT_Uniforms_F": {{_crate addItemCargoGlobal [_x select 0, _x select 1]}forEach _insClothes};
 };

--- a/fnc/_server/ins/fn_ins_safehouseLoad.sqf
+++ b/fnc/_server/ins/fn_ins_safehouseLoad.sqf
@@ -13,6 +13,8 @@ private _fnc_CreateVehicle = {
     _obj allowDamage false;
     _obj attachTo [_centerObj, _attachToOffset];
     _obj setVectorDirAndUp [_vectorDirAndUp select 0, _vectorDirAndUp select 1];
+    [_obj, false, [3, -2, 2], 20] call ace_dragging_fnc_setDraggable;
+    [_obj, false, [0, 3, 1], 10] call ace_dragging_fnc_setCarryable;
     _arrayToDetach pushBack _obj;
     [_obj, _type] call server_fnc_ins_safehouseEquipment;
     _obj;

--- a/mission.sqm
+++ b/mission.sqm
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=43;
+		nextID=47;
 	};
 	class Camera
 	{
-		pos[]={4011.4053,88.78125,4126.4873};
-		dir[]={0.53473788,-0.74034965,-0.40766123};
-		up[]={0.5887472,0.67221922,-0.44883826};
-		aside[]={-0.60634291,-3.0540396e-006,-0.79535896};
+		pos[]={4707.521,33.910374,6199.3174};
+		dir[]={-0.10774887,-0.49589449,0.86167854};
+		up[]={-0.061530564,0.86838126,0.49206808};
+		aside[]={0.99227673,-1.4874968e-007,0.1240788};
 	};
 };
 binarizationWanted=0;
@@ -23516,7 +23516,7 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="call{this addAction[""<t color='#B570E8C9'> Loadout </t>"", { createDialog ""dialog_LoadoutRequest"" }]; }";
+				init="call{this addAction[""<t color='#B570E8C9'>Loadout</t>"", { createDialog ""dialog_LoadoutRequest"" },"""",6,true,false,"""",""(side player == west)""]; }";
 				name="loadoutShop";
 			};
 			id=2301;


### PR DESCRIPTION
safehouse ammo boxes can no longer be moved.

loadout addactions added to the top of the action menu.